### PR TITLE
Add shared common.css for tools

### DIFF
--- a/content/tools/html/3mf-inspector/tool.html
+++ b/content/tools/html/3mf-inspector/tool.html
@@ -4,16 +4,15 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>3MF Inspector</title>
+    <link rel="stylesheet" href="/common.css" />
     <style>
       :root {
-        color-scheme: light;
-        font-family: "Bookerly", "Georgia", "Times New Roman", serif;
-        background: #f6f1ea;
-        color: #1d1b16;
+        --bg: #f6f1ea;
+        --ink: #1d1b16;
+        --font-body: "Bookerly", "Georgia", "Times New Roman", serif;
       }
 
       body {
-        margin: 0;
         padding: 24px;
       }
 
@@ -30,11 +29,6 @@
         margin: 0 0 8px;
         font-size: 2rem;
         letter-spacing: 0.02em;
-      }
-
-      p {
-        margin: 0 0 12px;
-        line-height: 1.5;
       }
 
       .panel {

--- a/content/tools/html/github-actions-spider/tool.html
+++ b/content/tools/html/github-actions-spider/tool.html
@@ -10,10 +10,10 @@
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Mulish:wght@300;400;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="/common.css" />
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
     <style>
       :root {
-        color-scheme: light;
         --bg: #f6f2ee;
         --panel: #fffdfa;
         --ink: #1c1a16;
@@ -26,16 +26,10 @@
         --success: #1f6f3d;
         --warning: #c35a12;
         --error: #9b1c1c;
-      }
-
-      * {
-        box-sizing: border-box;
+        --font-body: "Mulish", "Segoe UI", system-ui, sans-serif;
       }
 
       body {
-        margin: 0;
-        font-family: "Mulish", "Segoe UI", system-ui, sans-serif;
-        color: var(--ink);
         background: radial-gradient(circle at top left, #fff5ec 0%, var(--bg) 55%, #efe5dc 100%);
         min-height: 100vh;
       }

--- a/content/tools/html/hello-world/tool.html
+++ b/content/tools/html/hello-world/tool.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Hello, World Test</title>
+    <link rel="stylesheet" href="/common.css" />
     <style>
         body {
             font-family: Arial, sans-serif;

--- a/content/tools/html/helm-chart-discovery/tool.html
+++ b/content/tools/html/helm-chart-discovery/tool.html
@@ -10,9 +10,9 @@
       href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;700&family=Source+Sans+3:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="/common.css" />
     <style>
       :root {
-        color-scheme: light;
         --bg: #f4f2ee;
         --panel: #fffdf9;
         --ink: #1c1a18;
@@ -22,16 +22,10 @@
         --accent-soft: #f9e8df;
         --border: #e2d8cf;
         --shadow: 0 18px 40px rgba(20, 12, 4, 0.08);
-      }
-
-      * {
-        box-sizing: border-box;
+        --font-body: "Source Sans 3", "Segoe UI", system-ui, sans-serif;
       }
 
       body {
-        margin: 0;
-        font-family: "Source Sans 3", "Segoe UI", system-ui, sans-serif;
-        color: var(--ink);
         background: radial-gradient(circle at top right, #fff7ee 0%, var(--bg) 55%, #efe7df 100%);
         min-height: 100vh;
       }

--- a/content/tools/html/k9s-log-cleaner/tool.html
+++ b/content/tools/html/k9s-log-cleaner/tool.html
@@ -5,9 +5,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>K9s Log Cleaner</title>
+    <link rel="stylesheet" href="/common.css" />
     <style>
         :root {
-            color-scheme: light;
             --bg: #f7f6f2;
             --panel: #ffffff;
             --ink: #1f1f1d;
@@ -19,18 +19,12 @@
             --warning-bg: #fff0e6;
             --alert: #7a2417;
             --alert-bg: #ffe1dd;
-        }
-
-        * {
-            box-sizing: border-box;
+            --font-body: "Noto Sans", "Helvetica Neue", Arial, sans-serif;
         }
 
         body {
-            margin: 0;
             padding: 24px;
             background: var(--bg);
-            color: var(--ink);
-            font-family: "Noto Sans", "Helvetica Neue", Arial, sans-serif;
             line-height: 1.5;
         }
 

--- a/content/tools/html/url-inspect-rewrite/tool.html
+++ b/content/tools/html/url-inspect-rewrite/tool.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>URL Inspect & Rewrite</title>
+    <link rel="stylesheet" href="/common.css" />
     <style>
       :root {
-        color-scheme: light;
         --bg: #f7f5f0;
         --panel: #ffffff;
         --ink: #1d1d1f;
@@ -15,16 +15,10 @@
         --accent-soft: #e6f2ef;
         --border: #e2dfd8;
         --shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
-      }
-
-      * {
-        box-sizing: border-box;
+        --font-body: "Segoe UI", "Noto Sans", system-ui, sans-serif;
       }
 
       body {
-        margin: 0;
-        font-family: "Segoe UI", "Noto Sans", system-ui, sans-serif;
-        color: var(--ink);
         background: radial-gradient(circle at top, #fefdfb 0%, var(--bg) 60%, #efe9df 100%);
       }
 
@@ -64,28 +58,6 @@
         font-size: 1.2rem;
       }
 
-      label {
-        font-weight: 600;
-        display: block;
-        margin-bottom: 6px;
-      }
-
-      textarea,
-      input[type="text"] {
-        width: 100%;
-        border: 1px solid var(--border);
-        border-radius: 10px;
-        padding: 10px 12px;
-        font-size: 0.95rem;
-        font-family: "SF Mono", "Menlo", "Consolas", monospace;
-        background: #fbfaf7;
-      }
-
-      textarea {
-        min-height: 90px;
-        resize: vertical;
-      }
-
       .row {
         display: flex;
         gap: 12px;
@@ -103,19 +75,7 @@
         flex-wrap: wrap;
       }
 
-      button {
-        border: 1px solid var(--border);
-        background: var(--accent-soft);
-        color: var(--accent);
-        padding: 8px 14px;
-        border-radius: 999px;
-        font-weight: 600;
-        cursor: pointer;
-        transition: transform 0.15s ease, box-shadow 0.15s ease;
-      }
-
       button:hover {
-        transform: translateY(-1px);
         box-shadow: 0 6px 16px rgba(31, 111, 95, 0.18);
       }
 

--- a/content/tools/html/url-markdown-links/tool.html
+++ b/content/tools/html/url-markdown-links/tool.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>URL to Markdown Links</title>
+    <link rel="stylesheet" href="/common.css" />
     <style>
       :root {
-        color-scheme: light;
         --ink: #1e2a32;
         --muted: #5e6b75;
         --paper: #f7f2ec;
@@ -16,16 +16,11 @@
         --accent-soft: #f1d9c8;
         --shadow: 0 12px 30px rgba(32, 29, 26, 0.08);
         --radius: 16px;
-      }
-
-      * {
-        box-sizing: border-box;
+        --border: var(--line);
+        --font-body: "IBM Plex Sans", "Trebuchet MS", "Segoe UI", sans-serif;
       }
 
       body {
-        margin: 0;
-        font-family: "IBM Plex Sans", "Trebuchet MS", "Segoe UI", sans-serif;
-        color: var(--ink);
         background: radial-gradient(circle at top, #fff7ee 0%, var(--paper) 42%, #f1ece5 100%);
       }
 

--- a/static/common.css
+++ b/static/common.css
@@ -1,0 +1,95 @@
+:root {
+  color-scheme: light;
+  --bg: #ffffff;
+  --panel: #ffffff;
+  --ink: #1f1f1f;
+  --muted: #5f5f5f;
+  --border: #e0e0e0;
+  --accent: #2f6f5f;
+  --accent-soft: #e6f2ef;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  --radius: 14px;
+  --font-body: "Noto Sans", "Segoe UI", system-ui, sans-serif;
+  --font-mono: "SF Mono", "Menlo", "Consolas", monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  background: var(--bg);
+  font-family: var(--font-body);
+  line-height: 1.5;
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 2rem;
+  letter-spacing: -0.02em;
+}
+
+h2 {
+  margin: 0 0 10px;
+  font-size: 1.25rem;
+}
+
+p {
+  margin: 0 0 12px;
+}
+
+p.lead {
+  color: var(--muted);
+  max-width: 70ch;
+}
+
+label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 6px;
+}
+
+input[type="text"],
+input[type="url"],
+input[type="search"],
+input[type="email"],
+input[type="number"],
+textarea,
+select {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) - 4px);
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  font-family: var(--font-mono);
+  background: #fbfaf7;
+  color: var(--ink);
+}
+
+textarea {
+  min-height: 90px;
+  resize: vertical;
+}
+
+button {
+  border: 1px solid var(--border);
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- add shared `static/common.css` for baseline typography/forms/buttons
- wire common stylesheet into HTML tools and trim duplicated base rules
- preserve per-tool theme tokens and typography via CSS variables

## Testing
- not run (static/style-only changes)
