### PR TITLE
Add dependency analytics shortcodes

### DIFF
--- a/content/tools/dependencies.md
+++ b/content/tools/dependencies.md
@@ -1,0 +1,25 @@
+---
+title: "External Dependencies"
+---
+
+<div class="book">
+
+# External Dependencies
+
+The general spirit of this site is to have tools that are self-contained so the maintenance burden is low.
+However, in some cases, external dependencies are necessary to provide certain functionality without a huge amount of custom code.
+
+At a certain point, a dependency is less of a liability than building and maintaining the functionality yourself.
+
+Below is a list of the various external dependencies used by the tools on this site.
+</div>
+
+## High level statistics
+
+{{< tool-dependencies-summary >}}
+
+## Dependencies by Tool
+
+Only tools with external dependencies are listed here.
+
+{{< tool-dependencies-breakdown >}}

--- a/layouts/shortcodes/tool-dependencies-breakdown.html
+++ b/layouts/shortcodes/tool-dependencies-breakdown.html
@@ -1,0 +1,100 @@
+{{- /* Shortcode: render dependency breakdown per tool, grouped by tool language.
+Usage: {{< tool-dependencies-breakdown >}} */ -}}
+
+{{- $tools := site.Data.tools.tools -}}
+{{- $itemHeading := .Get "item_class" | default "h3" -}}
+{{- $allowedHeadings := dict "h2" true "h3" true "h4" true "h5" true "h6" true -}}
+{{- if not (index $allowedHeadings $itemHeading) -}}
+{{- $itemHeading = "h3" -}}
+{{- end -}}
+{{- $toolList := slice -}}
+{{- range $item := $tools -}}
+{{- range $slug, $tool := $item -}}
+{{- $toolList = $toolList | append (dict
+    "slug" $slug
+    "title" $tool.title
+    "language" ($tool.language | default "unknown")
+    "dependencies" ($tool.dependencies | default (slice))
+) -}}
+{{- end -}}
+{{- end -}}
+
+{{- $byLanguage := dict -}}
+{{- range $tool := $toolList -}}
+{{- $lang := $tool.language -}}
+{{- $list := index $byLanguage $lang | default (slice) -}}
+{{- $list = $list | append $tool -}}
+{{- $byLanguage = merge $byLanguage (dict $lang $list) -}}
+{{- end -}}
+
+{{- $languages := slice -}}
+{{- range $lang, $toolsForLang := $byLanguage -}}
+{{- $hasDeps := false -}}
+{{- range $tool := $toolsForLang -}}
+{{- if gt (len $tool.dependencies) 0 -}}
+{{- $hasDeps = true -}}
+{{- end -}}
+{{- end -}}
+{{- if $hasDeps -}}
+{{- $languages = $languages | append $lang -}}
+{{- end -}}
+{{- end -}}
+{{- $languages = sort $languages -}}
+
+<section class="tool-dependencies-breakdown">
+  {{- range $lang := $languages -}}
+  {{- $toolsForLang := index $byLanguage $lang -}}
+  {{- $toolsForLang = sort $toolsForLang "title" -}}
+  <div class="tool-dependencies-language" data-language="{{ $lang }}">
+    {{- printf "<%s class=\"tool-dependencies-language-heading\">%s</%s>" $itemHeading (title $lang) $itemHeading | safeHTML -}}
+    <div class="tool-dependencies-language-tools">
+      {{- range $tool := $toolsForLang -}}
+      {{- $deps := $tool.dependencies -}}
+      {{- if gt (len $deps) 0 -}}
+      <article class="tool-dependencies-tool" id="tool-deps-{{ $tool.slug | urlize }}">
+        <h3 class="tool-dependencies-tool-heading">
+          <a href="{{ printf "/tools/%s/" $tool.slug | relURL }}">{{ $tool.title }}</a>
+        </h3>
+        <p class="tool-dependencies-count">This tool relies on {{ len $deps }} dependencies.</p>
+        <div class="tool-dependencies">
+          <table>
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Library</th>
+                <th>Version</th>
+                <th>Via</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{- range $idx, $dep := $deps -}}
+              {{- $package := $dep.package | default "" -}}
+              {{- $version := $dep.version | default "" -}}
+              {{- $via := $dep.via | default "" -}}
+              <tr>
+                <td>{{ add $idx 1 }}</td>
+                <td>{{ $package }}</td>
+                <td>{{ if $version }}{{ $version }}{{ else }}&mdash;{{ end }}</td>
+                <td>
+                  {{- if $via -}}
+                  {{- $host := "" -}}
+                  {{- with (urls.Parse $via) -}}
+                  {{- if .Host -}}{{- $host = .Host -}}{{- end -}}
+                  {{- end -}}
+                  <a href="{{ $via }}">{{ if $host }}{{ $host }}{{ else }}{{ $via }}{{ end }}</a>
+                  {{- else -}}
+                  &mdash;
+                  {{- end -}}
+                </td>
+              </tr>
+              {{- end -}}
+            </tbody>
+          </table>
+        </div>
+      </article>
+      {{- end -}}
+      {{- end -}}
+    </div>
+  </div>
+  {{- end -}}
+</section>

--- a/layouts/shortcodes/tool-dependencies-summary.html
+++ b/layouts/shortcodes/tool-dependencies-summary.html
@@ -1,0 +1,148 @@
+{{- /* Shortcode: render dependency analytics summary across all tools.
+Usage: {{< tool-dependencies-summary >}} */ -}}
+
+{{- $tools := site.Data.tools.tools -}}
+{{- $itemHeading := .Get "item_class" | default "h3" -}}
+{{- $allowedHeadings := dict "h2" true "h3" true "h4" true "h5" true "h6" true -}}
+{{- if not (index $allowedHeadings $itemHeading) -}}
+{{- $itemHeading = "h3" -}}
+{{- end -}}
+{{- $totalTools := len $tools -}}
+{{- $toolsWithDeps := 0 -}}
+{{- $depCounts := dict -}}
+{{- $languages := dict -}}
+{{- $cdnCounts := dict -}}
+
+{{- range $item := $tools -}}
+{{- range $_, $tool := $item -}}
+{{- $deps := $tool.dependencies | default (slice) -}}
+{{- $language := $tool.language | default "unknown" -}}
+{{- if gt (len $deps) 0 -}}
+{{- $toolsWithDeps = add $toolsWithDeps 1 -}}
+{{- $seen := dict -}}
+{{- range $dep := $deps -}}
+{{- $package := $dep.package | default "" -}}
+{{- $version := $dep.version | default "" -}}
+{{- $depKey := printf "%s||%s||%s" $language $package $version -}}
+{{- if not (index $seen $depKey) -}}
+{{- $seen = merge $seen (dict $depKey true) -}}
+{{- $current := index $depCounts $depKey | default 0 -}}
+{{- $depCounts = merge $depCounts (dict $depKey (add $current 1)) -}}
+{{- end -}}
+{{- with $dep.via -}}
+{{- $host := "" -}}
+{{- with (urls.Parse .) -}}
+{{- if .Host -}}{{- $host = .Host -}}{{- end -}}
+{{- end -}}
+{{- if $host -}}
+{{- $cdnCurrent := index $cdnCounts $host | default 0 -}}
+{{- $cdnCounts = merge $cdnCounts (dict $host (add $cdnCurrent 1)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $languages = merge $languages (dict $language true) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- $toolsWithoutDeps := sub $totalTools $toolsWithDeps -}}
+{{- $languageList := slice -}}
+{{- range $lang, $_ := $languages -}}
+{{- $languageList = $languageList | append $lang -}}
+{{- end -}}
+{{- $languageList = sort $languageList -}}
+
+<section class="tool-dependencies-summary">
+  <div class="tool-dependencies-summary-metrics">
+    <table>
+      <thead>
+        <tr>
+          <th>Total Tools</th>
+          <th>Tools Using Dependencies</th>
+          <th>Tools Without Dependencies</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{{ $totalTools }}</td>
+          <td>{{ $toolsWithDeps }}</td>
+          <td>{{ $toolsWithoutDeps }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  {{- $cdnList := slice -}}
+  {{- range $host, $count := $cdnCounts -}}
+  {{- $cdnList = $cdnList | append (dict "host" $host "count" $count) -}}
+  {{- end -}}
+  {{- $cdnList = sort $cdnList "host" -}}
+  {{- $cdnList = sort $cdnList "count" "desc" -}}
+
+  {{- if $cdnList -}}
+  <div class="tool-dependencies-summary-cdns">
+    <table>
+      <thead>
+        <tr>
+          <th>CDN Host</th>
+          <th>Use Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{- range $cdn := $cdnList -}}
+        <tr>
+          <td>{{ $cdn.host }}</td>
+          <td>{{ $cdn.count }}</td>
+        </tr>
+        {{- end -}}
+      </tbody>
+    </table>
+  </div>
+  {{- end -}}
+
+  {{- if not $depCounts -}}
+  <p class="tool-dependencies-summary-empty">No external dependencies listed.</p>
+  {{- else -}}
+  {{- range $lang := $languageList -}}
+  {{- $depList := slice -}}
+  {{- range $key, $count := $depCounts -}}
+  {{- $parts := split $key "||" -}}
+  {{- $keyLang := index $parts 0 -}}
+  {{- if eq $keyLang $lang -}}
+  {{- $package := index $parts 1 -}}
+  {{- $version := index $parts 2 -}}
+  {{- $depList = $depList | append (dict "package" $package "version" $version "count" $count) -}}
+  {{- end -}}
+  {{- end -}}
+
+  {{- if gt (len $depList) 0 -}}
+  {{- $depList = sort $depList "package" -}}
+  {{- $depList = sort $depList "version" -}}
+  {{- $depList = sort $depList "count" "desc" -}}
+  <div class="tool-dependencies-summary-language" data-language="{{ $lang }}">
+    {{- printf "<%s class=\"tool-dependencies-summary-heading\">%s</%s>" $itemHeading (title $lang) $itemHeading | safeHTML -}}
+    <div class="tool-dependencies-summary-table">
+      <table>
+        <thead>
+          <tr>
+            <th>Dependency</th>
+            <th>Version</th>
+            <th>Use Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{- range $dep := $depList -}}
+          <tr>
+            <td>{{ $dep.package }}</td>
+            <td>{{ if $dep.version }}{{ $dep.version }}{{ else }}&mdash;{{ end }}</td>
+            <td>{{ $dep.count }}</td>
+          </tr>
+          {{- end -}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {{- end -}}
+  {{- end -}}
+  {{- end -}}
+</section>


### PR DESCRIPTION
## Summary
- add dependency summary and breakdown shortcodes for tools analytics
- render dependency metrics/tables on external dependencies page
- include CDN host usage and language-grouped dependency tables

## Testing
- not run (content change)