### PR TITLE
Add include/exclude globs to gha tree builder

### DIFF
--- a/content/tools/python/gha-tree-builder/index.md
+++ b/content/tools/python/gha-tree-builder/index.md
@@ -26,7 +26,7 @@ tags:
 
 Map GitHub Actions workflows into a dependency graph that includes trigger nodes, workflow nodes, and job nodes.
 The output is [DOT syntax](https://graphviz.org/doc/info/lang.html) so you can render with Graphviz or any compatible tool.
-If you have Graphviz installed and in your PATH, the tool can also render directly to PNG, SVG, or other formats.
+If you have Graphviz installed and in your PATH, the tool can also render directly to PNG, SVG, WEBP, or other formats.
 
 ## Example Usage
 
@@ -42,6 +42,9 @@ If you have Graphviz installed and in your PATH, the tool can also render direct
 # Same defaults, but also render a PNG (requires Graphviz in PATH)
 ./tool.py --render=gha-tree.png
 
+# Render WEBP and skip writing the DOT file
+./tool.py --render=gha-tree.webp --no-dot
+
 # Respect explicit CLI options
 ./tool.py --workflow-root=/mnt/some/example/.github/workflows \
   --output=/mnt/other/location/example.dot
@@ -49,6 +52,13 @@ If you have Graphviz installed and in your PATH, the tool can also render direct
 # Allow env-vars to set CLI args as well
 GHA_TREE_BUILDER_WORKFLOW_ROOT=/mnt/some/example/.github/workflows \
   ./tool.py --output=/mnt/other/location/example.dot
+
+# Limit parsing to matching workflow files
+./tool.py some-prefix*.yaml
+
+# Include or exclude specific workflow files (mutually exclusive)
+./tool.py --workflow-root=.github/workflows --include-glob='some-prefix*.yaml'
+./tool.py --workflow-root=.github/workflows --exclude-glob='*-legacy.yml'
 ```
 
 ## Example Output

--- a/content/tools/python/gha-tree-builder/tool.py
+++ b/content/tools/python/gha-tree-builder/tool.py
@@ -12,6 +12,7 @@
 
 from __future__ import annotations
 
+import glob
 import logging
 from dataclasses import dataclass
 import hashlib
@@ -56,18 +57,47 @@ def configure_logging(verbose: bool) -> structlog.stdlib.BoundLogger:
     return structlog.get_logger()
 
 
-def list_workflow_files(root: Path) -> list[Path]:
+def resolve_globs(root: Path, globs: Iterable[str]) -> set[Path]:
+    matches: set[Path] = set()
+    for pattern in globs:
+        pattern_path = Path(pattern)
+        if pattern_path.is_absolute():
+            for match in glob.glob(pattern):
+                matches.add(Path(match))
+        else:
+            matches.update(root.glob(pattern))
+    return matches
+
+
+def list_workflow_files(
+    root: Path,
+    patterns: Iterable[str] | None = None,
+    include_globs: Iterable[str] | None = None,
+    exclude_globs: Iterable[str] | None = None,
+) -> list[Path]:
     if not root.exists():
         raise FileNotFoundError(f"Workflow root not found: {root}")
     if not root.is_dir():
         raise NotADirectoryError(f"Workflow root is not a directory: {root}")
 
-    files = [
+    candidates: list[Path]
+    if patterns:
+        candidates = sorted(resolve_globs(root, patterns))
+    else:
+        candidates = sorted(root.iterdir())
+
+    if include_globs:
+        include_matches = resolve_globs(root, include_globs)
+        candidates = [path for path in candidates if path in include_matches]
+    if exclude_globs:
+        exclude_matches = resolve_globs(root, exclude_globs)
+        candidates = [path for path in candidates if path not in exclude_matches]
+
+    return [
         path
-        for path in sorted(root.iterdir())
+        for path in candidates
         if path.is_file() and path.suffix in {".yml", ".yaml"}
     ]
-    return files
 
 
 def load_yaml(path: Path, logger: structlog.stdlib.BoundLogger) -> dict[object, Any]:
@@ -308,10 +338,19 @@ def build_workflow_map(workflows: Iterable[WorkflowInfo]) -> dict[str, str]:
 
 
 def collect_workflows(
-    root: Path, logger: structlog.stdlib.BoundLogger
+    root: Path,
+    logger: structlog.stdlib.BoundLogger,
+    patterns: Iterable[str] | None = None,
+    include_globs: Iterable[str] | None = None,
+    exclude_globs: Iterable[str] | None = None,
 ) -> list[WorkflowInfo]:
     workflows = []
-    for path in list_workflow_files(root):
+    for path in list_workflow_files(
+        root,
+        patterns=patterns,
+        include_globs=include_globs,
+        exclude_globs=exclude_globs,
+    ):
         raw = load_yaml(path, logger)
         if not raw:
             continue
@@ -328,8 +367,23 @@ def write_dot(graph: pydot.Dot, output: Path) -> None:
     output.write_text(graph.to_string(), encoding="utf-8")
 
 
-def render_png(graph: pydot.Dot, output: Path) -> None:
-    graph.write_png(str(output))
+def render_graph(graph: pydot.Dot, output: Path) -> None:
+    suffix = output.suffix.lower().lstrip(".")
+    if not suffix:
+        raise click.ClickException(
+            "Render output must include a file extension to infer the format."
+        )
+
+    format_map = {"jpg": "jpeg"}
+    fmt = format_map.get(suffix, suffix)
+    supported = {"png", "svg", "pdf", "webp", "jpeg"}
+    if fmt not in supported:
+        raise click.ClickException(f"Unsupported render format: .{suffix}")
+
+    if fmt == "png":
+        graph.write_png(str(output))
+        return
+    graph.write(str(output), format=fmt)
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
@@ -352,8 +406,37 @@ def render_png(graph: pydot.Dot, output: Path) -> None:
     type=click.Path(dir_okay=False, path_type=Path),
     default=None,
     envvar="GHA_TREE_BUILDER_RENDER",
-    help="Render PNG output (requires Graphviz in PATH).",
+    help=(
+        "Render graph output (format inferred from extension; requires Graphviz in PATH)."
+    ),
 )
+@click.option(
+    "--no-dot",
+    is_flag=True,
+    envvar="GHA_TREE_BUILDER_NO_DOT",
+    help="Skip writing the DOT output file.",
+)
+@click.option(
+    "--include-glob",
+    "include_globs",
+    multiple=True,
+    envvar="GHA_TREE_BUILDER_INCLUDE_GLOB",
+    help=(
+        "Only include workflow files matching glob(s). Mutually exclusive with "
+        "--exclude-glob and positional patterns."
+    ),
+)
+@click.option(
+    "--exclude-glob",
+    "exclude_globs",
+    multiple=True,
+    envvar="GHA_TREE_BUILDER_EXCLUDE_GLOB",
+    help=(
+        "Exclude workflow files matching glob(s). Mutually exclusive with "
+        "--include-glob and positional patterns."
+    ),
+)
+@click.argument("patterns", nargs=-1)
 @click.option(
     "--verbose",
     is_flag=True,
@@ -364,6 +447,10 @@ def main(
     workflow_root: Path | None,
     output: Path | None,
     render: Path | None,
+    no_dot: bool,
+    include_globs: tuple[str, ...],
+    exclude_globs: tuple[str, ...],
+    patterns: tuple[str, ...],
     verbose: bool,
 ) -> None:
     """Generate a DOT file describing GitHub Actions workflow dependencies."""
@@ -372,25 +459,52 @@ def main(
     root = workflow_root or Path.cwd()
     output_path = output or (Path.cwd() / "gha-tree.dot")
 
-    logger.info("building_graph", workflow_root=str(root), output=str(output_path))
+    if include_globs and exclude_globs:
+        raise click.ClickException(
+            "--include-glob and --exclude-glob cannot be used together."
+        )
+    if patterns and (include_globs or exclude_globs):
+        raise click.ClickException(
+            "Positional patterns cannot be combined with --include-glob or --exclude-glob."
+        )
 
-    workflows = collect_workflows(root, logger)
+    log_payload: dict[str, Any] = {"workflow_root": str(root)}
+    if not no_dot:
+        log_payload["output"] = str(output_path)
+    if patterns:
+        log_payload["patterns"] = list(patterns)
+    if include_globs:
+        log_payload["include_glob"] = list(include_globs)
+    if exclude_globs:
+        log_payload["exclude_glob"] = list(exclude_globs)
+    logger.info("building_graph", **log_payload)
+
+    workflows = collect_workflows(
+        root,
+        logger,
+        patterns=patterns or None,
+        include_globs=include_globs or None,
+        exclude_globs=exclude_globs or None,
+    )
     if not workflows:
         logger.warning("no_workflows_found", workflow_root=str(root))
 
     workflow_map = build_workflow_map(workflows)
     graph = build_graph(workflows, workflow_map)
 
-    try:
-        write_dot(graph, output_path)
-        logger.info("dot_written", output=str(output_path))
-    except OSError as exc:
-        raise click.ClickException(f"Failed to write DOT file: {exc}") from exc
+    if not no_dot:
+        try:
+            write_dot(graph, output_path)
+            logger.info("dot_written", output=str(output_path))
+        except OSError as exc:
+            raise click.ClickException(f"Failed to write DOT file: {exc}") from exc
+    else:
+        logger.info("dot_skipped", reason="--no-dot")
 
     if render:
         try:
             logger.info("rendering_graph", output=str(render))
-            render_png(graph, render)
+            render_graph(graph, render)
             logger.info("render_written", output=str(render))
         except (
             Exception
@@ -465,6 +579,74 @@ jobs:
 
     dot = graph.to_string()
     assert "label=needs" in dot
+
+
+def test_collect_workflows_with_patterns(tmp_path: Path) -> None:
+    workflow_a = tmp_path / "some-prefix-ci.yaml"
+    workflow_b = tmp_path / "other.yml"
+
+    workflow_a.write_text(
+        """
+name: Workflow A
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+""".strip(),
+        encoding="utf-8",
+    )
+
+    workflow_b.write_text(
+        """
+name: Workflow B
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+""".strip(),
+        encoding="utf-8",
+    )
+
+    logger = configure_logging(False)
+    workflows = collect_workflows(tmp_path, logger, patterns=("some-prefix*.yaml",))
+
+    assert [workflow.name for workflow in workflows] == ["Workflow A"]
+
+
+def test_collect_workflows_with_exclude_glob(tmp_path: Path) -> None:
+    workflow_a = tmp_path / "ci.yaml"
+    workflow_b = tmp_path / "ci-legacy.yml"
+
+    workflow_a.write_text(
+        """
+name: Workflow A
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+""".strip(),
+        encoding="utf-8",
+    )
+
+    workflow_b.write_text(
+        """
+name: Workflow B
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+""".strip(),
+        encoding="utf-8",
+    )
+
+    logger = configure_logging(False)
+    workflows = collect_workflows(
+        tmp_path,
+        logger,
+        exclude_globs=("*-legacy.yml",),
+    )
+
+    assert [workflow.name for workflow in workflows] == ["Workflow A"]
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ name = "tools"
 version = "0.1.0"
 requires-python = ">=3.14"
 dependencies = [
+    "click>=8.3.1",
+    "pydot>=4.0.1",
+    "pyyaml>=6.0.3",
     "structlog>=25.5.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -184,6 +196,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pydot"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -202,6 +226,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -286,6 +319,9 @@ name = "tools"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "click" },
+    { name = "pydot" },
+    { name = "pyyaml" },
     { name = "structlog" },
 ]
 
@@ -310,7 +346,12 @@ tool-dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "structlog", specifier = ">=25.5.0" }]
+requires-dist = [
+    { name = "click", specifier = ">=8.3.1" },
+    { name = "pydot", specifier = ">=4.0.1" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "structlog", specifier = ">=25.5.0" },
+]
 
 [package.metadata.requires-dev]
 ci-detect-tools-changes = [{ name = "pyyaml", specifier = ">=6.0.3" }]


### PR DESCRIPTION
## Summary
- add include/exclude glob filters for workflow selection and enforce mutual exclusivity
- support format-aware rendering (incl. webp) and optional DOT skipping
- expand gha tree builder docs and tests for new filtering options

## Testing
- pytest content/tools/python/gha-tree-builder/tool.py
