### PR TITLE
Add dark-mode styling for analytics and key tools

### DIFF
--- a/content/tools/html/makefile-dependency-graph/tool.html
+++ b/content/tools/html/makefile-dependency-graph/tool.html
@@ -16,18 +16,65 @@
         --muted: #5f5c57;
         --paper: #f5f1ea;
         --paper-alt: #efe7dd;
+        --paper-top: #fff6e8;
         --surface: #ffffff;
         --surface-elevated: #fff9f2;
         --line: #d7cbbf;
         --accent: #e06f3d;
         --accent-strong: #c55b2f;
         --accent-soft: rgba(224, 111, 61, 0.15);
+        --drop-bg: #fff7ed;
+        --drop-active: #fff1e3;
+        --input-bg: #fffdf9;
+        --subcard-bg: #fffefc;
+        --render-bg: #fffdf8;
+        --status-bg: #fffdf8;
+        --status-divider: #e2d7cb;
+        --status-heading: #6b5a4a;
+        --status-tag: #7a6a5c;
+        --status-missing: #b4574f;
+        --console-bg: #1a1917;
+        --console-border: #3b342c;
+        --console-ink: #f0e5d8;
+        --console-muted: #9a8f84;
         --shadow: 0 18px 38px rgba(66, 49, 32, 0.16);
         --radius: 18px;
         --radius-sm: 12px;
         --mono: "Source Code Pro", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
           "Liberation Mono", "Courier New", monospace;
         --body: "Space Grotesk", "Trebuchet MS", "Segoe UI", sans-serif;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          color-scheme: dark;
+          --ink: #e9ecef;
+          --muted: #c6cbd1;
+          --paper: #2a3036;
+          --paper-alt: #242a30;
+          --paper-top: #2b3238;
+          --surface: #333a41;
+          --surface-elevated: #2f363c;
+          --line: #4f565e;
+          --accent: #ff9f6b;
+          --accent-strong: #ff8a4b;
+          --accent-soft: rgba(255, 159, 107, 0.2);
+          --drop-bg: #2b3238;
+          --drop-active: #313942;
+          --input-bg: #2a3036;
+          --subcard-bg: #2c3339;
+          --render-bg: #2a3036;
+          --status-bg: #2a3036;
+          --status-divider: #3f4750;
+          --status-heading: #b9b0a3;
+          --status-tag: #c7bdb2;
+          --status-missing: #ff9a90;
+          --console-bg: #1b1f24;
+          --console-border: #3a424a;
+          --console-ink: #e9ecef;
+          --console-muted: #9aa3ad;
+          --shadow: 0 18px 38px rgba(0, 0, 0, 0.4);
+        }
       }
 
       * {
@@ -37,7 +84,7 @@
       body {
         margin: 0;
         font-family: var(--body);
-        background: radial-gradient(circle at top, #fff6e8, var(--paper) 45%, var(--paper-alt) 100%);
+        background: radial-gradient(circle at top, var(--paper-top), var(--paper) 45%, var(--paper-alt) 100%);
         color: var(--ink);
       }
 
@@ -123,7 +170,8 @@
         border: 1px solid var(--line);
         font-family: var(--mono);
         font-size: 0.95rem;
-        background: #fffdf9;
+        background: var(--input-bg);
+        color: var(--ink);
       }
 
       textarea:focus {
@@ -137,12 +185,12 @@
         padding: 16px;
         text-align: center;
         color: var(--muted);
-        background: #fff7ed;
+        background: var(--drop-bg);
       }
 
       .drop-zone.dragover {
         border-color: var(--accent);
-        background: #fff1e3;
+        background: var(--drop-active);
         color: var(--ink);
       }
 
@@ -188,7 +236,7 @@
         border: 1px solid var(--line);
         border-radius: var(--radius-sm);
         padding: 14px;
-        background: #fffefc;
+        background: var(--subcard-bg);
         display: grid;
         gap: 10px;
       }
@@ -223,7 +271,7 @@
       .render-zone {
         border-radius: var(--radius-sm);
         border: 1px solid var(--line);
-        background: #fffdf8;
+        background: var(--render-bg);
         min-height: 280px;
         padding: 12px;
         overflow: auto;
@@ -235,18 +283,18 @@
       }
 
       .console {
-        background: #1a1917;
+        background: var(--console-bg);
         border-radius: var(--radius-sm);
         padding: 12px;
-        color: #f0e5d8;
+        color: var(--console-ink);
         font-family: var(--mono);
         min-height: 140px;
         overflow: auto;
-        border: 1px solid #3b342c;
+        border: 1px solid var(--console-border);
       }
 
       .console .muted {
-        color: #9a8f84;
+        color: var(--console-muted);
       }
 
       .status-row {
@@ -257,7 +305,7 @@
       .status-box {
         border: 1px solid var(--line);
         border-radius: var(--radius-sm);
-        background: #fffdf8;
+        background: var(--status-bg);
         padding: 10px 12px;
         max-height: 160px;
         overflow: auto;
@@ -277,7 +325,7 @@
         justify-content: space-between;
         gap: 12px;
         padding: 4px 0;
-        border-bottom: 1px dashed #e2d7cb;
+        border-bottom: 1px dashed var(--status-divider);
       }
 
       .status-box .status-item:last-child {
@@ -294,7 +342,7 @@
 
       .status-box .status-heading {
         font-weight: 700;
-        color: #6b5a4a;
+        color: var(--status-heading);
         text-transform: uppercase;
         letter-spacing: 0.08em;
         font-size: 0.75rem;
@@ -303,11 +351,11 @@
 
       .status-box .status-tag {
         font-weight: 600;
-        color: #7a6a5c;
+        color: var(--status-tag);
       }
 
       .status-box .status-tag.missing {
-        color: #b4574f;
+        color: var(--status-missing);
       }
 
       @media (max-width: 720px) {

--- a/content/tools/html/yaml-json-convert-compare/tool.html
+++ b/content/tools/html/yaml-json-convert-compare/tool.html
@@ -8,6 +8,7 @@
       :root {
         color-scheme: light;
         --bg: #f7f5f0;
+        --bg-end: #f0eee9;
         --panel: #ffffff;
         --ink: #1f1f1f;
         --muted: #6a6a6a;
@@ -16,7 +17,28 @@
         --border: #dedad2;
         --danger: #a0302a;
         --success: #1b6a36;
+        --drop-bg: #faf9f6;
+        --input-bg: #fcfbf9;
         --shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          color-scheme: dark;
+          --bg: #262b31;
+          --bg-end: #1f2429;
+          --panel: #333a41;
+          --ink: #e9ecef;
+          --muted: #c5cbd1;
+          --accent: #84b2ff;
+          --accent-soft: #2f3a4a;
+          --border: #4f565e;
+          --danger: #e07a7a;
+          --success: #6dd087;
+          --drop-bg: #2d3339;
+          --input-bg: #2a3036;
+          --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+        }
       }
 
       * {
@@ -26,7 +48,7 @@
       body {
         margin: 0;
         font-family: "Georgia", "Times New Roman", serif;
-        background: linear-gradient(160deg, #f7f5f0 0%, #f0eee9 100%);
+        background: linear-gradient(160deg, var(--bg) 0%, var(--bg-end) 100%);
         color: var(--ink);
       }
 
@@ -99,7 +121,7 @@
         padding: 10px;
         text-align: center;
         color: var(--muted);
-        background: #faf9f6;
+        background: var(--drop-bg);
       }
 
       .drop-zone.dragover {
@@ -117,7 +139,8 @@
         padding: 12px;
         font-family: "Courier New", monospace;
         font-size: 0.92rem;
-        background: #fcfbf9;
+        background: var(--input-bg);
+        color: var(--ink);
       }
 
       .actions {
@@ -134,6 +157,7 @@
         border-radius: 10px;
         cursor: pointer;
         font-size: 0.9rem;
+        color: var(--ink);
       }
 
       button.primary {
@@ -146,7 +170,15 @@
         border: 1px solid var(--border);
         border-radius: 12px;
         padding: 8px 12px;
-        background: #fcfbf9;
+        background: var(--input-bg);
+      }
+
+      input,
+      select {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--input-bg);
+        color: var(--ink);
       }
 
       details summary {

--- a/static/analytics.html
+++ b/static/analytics.html
@@ -8,6 +8,41 @@
     <style>
         :root {
             color-scheme: light;
+            --bg: #fbfaf7;
+            --panel: #ffffff;
+            --ink: #222222;
+            --muted: #5f5a4d;
+            --border: #dddddd;
+            --border-soft: #e3e3e3;
+            --accent: #1d4f6d;
+            --accent-soft: #e7e0d1;
+            --accent-ink: #3f2e18;
+            --danger: #9b2f2f;
+            --table-header: #f3f1ea;
+            --table-hover: #faf8f2;
+            --input-bg: #f6f4ef;
+            --shadow: 0 6px 18px rgba(0, 0, 0, 0.04);
+            --radius: 10px;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                color-scheme: dark;
+                --bg: #2f343a;
+                --panel: #3a4046;
+                --ink: #e9ecef;
+                --muted: #c7c1b3;
+                --border: #5c6165;
+                --border-soft: #4f565e;
+                --accent: #84b2ff;
+                --accent-soft: #3b4148;
+                --accent-ink: #e9ecef;
+                --danger: #e07a7a;
+                --table-header: #343a40;
+                --table-hover: #2f363c;
+                --input-bg: #2e343a;
+                --shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+            }
         }
 
         body {
@@ -15,9 +50,9 @@
             margin: 2rem auto;
             max-width: 900px;
             padding: 0 1.5rem 3rem;
-            color: #222;
+            color: var(--ink);
             line-height: 1.55;
-            background: #fbfaf7;
+            background: var(--bg);
         }
 
         header {
@@ -33,12 +68,16 @@
             margin: 0.4rem 0;
         }
 
+        a {
+            color: var(--accent);
+        }
+
         .panel {
-            background: #ffffff;
-            border: 1px solid #ddd;
-            border-radius: 10px;
+            background: var(--panel);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
             padding: 1rem 1.25rem;
-            box-shadow: 0 6px 18px rgba(0, 0, 0, 0.04);
+            box-shadow: var(--shadow);
             margin-bottom: 1.2rem;
         }
 
@@ -60,18 +99,18 @@
         #analytics-table th,
         #analytics-table td {
             padding: 0.6rem 0.5rem;
-            border-bottom: 1px solid #e3e3e3;
+            border-bottom: 1px solid var(--border-soft);
             text-align: left;
             vertical-align: top;
         }
 
         #analytics-table th {
-            background: #f3f1ea;
+            background: var(--table-header);
             font-weight: 600;
         }
 
         #analytics-table tbody tr:hover {
-            background: #faf8f2;
+            background: var(--table-hover);
         }
 
         #export-actions,
@@ -103,18 +142,18 @@
             padding: 0.55rem 1.1rem;
             font-weight: 600;
             cursor: pointer;
-            background: #1d4f6d;
-            color: #fff;
+            background: var(--accent);
+            color: var(--panel);
         }
 
         button.secondary {
-            background: #e7e0d1;
-            color: #3f2e18;
+            background: var(--accent-soft);
+            color: var(--accent-ink);
         }
 
         button.danger {
-            background: #9b2f2f;
-            color: #fff;
+            background: var(--danger);
+            color: var(--panel);
         }
 
         button:disabled {
@@ -123,7 +162,7 @@
         }
 
         #analytics-empty {
-            color: #5f5a4d;
+            color: var(--muted);
             font-style: italic;
         }
 
@@ -133,8 +172,8 @@
             margin-top: 0.75rem;
             padding: 0.75rem;
             border-radius: 8px;
-            border: 1px solid #ccc;
-            background: #f6f4ef;
+            border: 1px solid var(--border);
+            background: var(--input-bg);
             font-family: "Courier New", monospace;
             font-size: 0.85rem;
             white-space: pre;

--- a/static/analytics.js
+++ b/static/analytics.js
@@ -70,9 +70,10 @@
                 #${FOOTER_ID} {
                     margin-top: 2.5rem;
                     padding: 0.85rem 1rem;
-                    border-top: 1px solid #d9d9d9;
-                    background: #f7f7f7;
-                    color: #444;
+                    border: 1px solid var(--border);
+                    border-radius: var(--radius);
+                    background: var(--panel);
+                    color: var(--muted);
                     font-size: 0.85rem;
                     display: flex;
                     flex-wrap: wrap;
@@ -80,7 +81,7 @@
                     align-items: center;
                 }
                 #${FOOTER_ID} a {
-                    color: inherit;
+                    color: var(--accent);
                     text-decoration: underline;
                     font-weight: 600;
                 }


### PR DESCRIPTION
## Summary
- align analytics footer styling with shared theme variables
- add dark-mode variables to analytics page
- add dark-mode palettes for yaml/json converter and makefile graph tools

## Testing
- not run