### PR TITLE
[codex] migrate repo orchestration to mise

### DIFF
--- a/.github/workflows/ci_pre-commit.yaml
+++ b/.github/workflows/ci_pre-commit.yaml
@@ -28,21 +28,19 @@ jobs:
                   persist-credentials: false
                   fetch-depth: 0
 
-            - name: Install uv
-              id: setup_uv
-              uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+            - name: Setup mise toolchain
+              id: setup_mise
+              uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
               with:
-                  enable-cache: true
-                  ignore-nothing-to-cache: true
+                  # renovate: datasource=github-tags depName=jdx/mise versioning=loose
+                  version: 2026.4.18
+                  install: true
+                  install_args: python uv
+                  cache: true
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  experimental: false
+                  log_level: ${{ env.ACTIONS_STEP_DEBUG && 'debug' || 'info' }}
 
-            - name: Set up Python And Pre-Commit
-              id: setup_python_pre-commit
-              run: |
-                  uv python install
-                  uv tool install pre-commit
-
-            # TODO: only if early steps succeeded
             - name: Run pre-commit hooks
               id: check_pre_commit
-              run: |
-                  uv run pre-commit run --all-files
+              run: mise run lint

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -43,77 +43,22 @@ jobs:
                   # Fetch Hugo theme
                   submodules: recursive
 
-            # Pre-requisites: Hugo binary and Python
-            - name: Setup Hugo
-              id: setup_hugo
-              # See: https://github.com/peaceiris/actions-hugo
-              uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
+            - name: Setup mise toolchain
+              id: setup_mise
+              uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
               with:
-                  # See: https://github.com/gohugoio/hugo/releases
-                  ##
-                  # renovate: datasource=github-tags depName=gohugoio/hugo versioning=semver
-                  hugo-version: "0.153.1"
-                  # Most themes require extended version for SCSS/SASS support
-                  extended: true
+                  # renovate: datasource=github-tags depName=jdx/mise versioning=loose
+                  version: 2026.4.18
+                  install: true
+                  install_args: python uv hugo-extended
+                  cache: true
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  experimental: false
+                  log_level: ${{ env.ACTIONS_STEP_DEBUG && 'debug' || 'info' }}
 
-            - name: Install uv
-              id: setup_uv
-              uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-              with:
-                  enable-cache: true
-                  ignore-nothing-to-cache: true
-
-            # As long as the page bundle is correct, hugo should just pick up the new tool and the like.
-            # To update the landing page, though, we need to regenerate the data file.
-            - name: Build data/tools.yaml
-              id: build_data_tools_yaml
-              run: |
-                  uv run ci/build_tools_data.py
-
-            - name: Build tool changelogs
-              id: build_tool_changelogs
-              run: |
-                  uv run ci/build_tool_changelogs.py
-
-            - name: Find modified tools data and changelogs
-              id: tools_data_changed
-              run: |
-                  CHANGES=()
-                  if ! git diff --quiet HEAD -- data/tools.yaml; then
-                    TOOLS_CHANGES=$(uv run ci/detect_tools_changes.py)
-                    if [ -z "$TOOLS_CHANGES" ]; then
-                      TOOLS_CHANGES="data/tools.yaml updated"
-                    fi
-                    CHANGES+=("$TOOLS_CHANGES")
-                  fi
-
-                  if ! git diff --quiet HEAD -- 'content/tools/**/changelog.md'; then
-                    COUNT=$(git diff --name-only HEAD -- 'content/tools/**/changelog.md' | wc -l | tr -d ' ')
-                    CHANGES+=("${COUNT} changelog(s) updated")
-                  fi
-
-                  if [ ${#CHANGES[@]} -eq 0 ]; then
-                    echo "changes=" >> $GITHUB_OUTPUT
-                  else
-                    echo "changes=$(IFS='; '; echo \"${CHANGES[*]}\")" >> $GITHUB_OUTPUT
-                  fi
-
-            - name: Commit and push if tools data or changelogs changed
-              id: commit_tools_data_changes
-              if: steps.tools_data_changed.outputs.changes != ''
-              env:
-                  CHANGES: ${{ steps.tools_data_changed.outputs.changes }}
-              run: |-
-                  git config user.name "Automated"
-                  git config user.email "actions@users.noreply.github.com"
-                  git add data/tools.yaml content/tools/**/changelog.md
-                  git commit -m "Updated tool data: ${CHANGES}" || exit 0
-                  git push
-
-            # Then use the updated tool data file to render out a new everything
-            - name: Build site
+            - name: Refresh generated files and build site
               id: build_site
-              run: hugo --minify
+              run: mise run release:build-pages
 
             # As far as I can tell, if you don't use the "legacy" pattern of pointing to a particular folder/branch, you must use the "official" actions
             ##

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
       hooks:
           - id: check-tool-analytics
             name: Check HTML tools include analytics.js
-            entry: uv run ci/check_tool_analytics.py
+            entry: mise run check:analytics --
             language: system
-            files: ^content/tools/html/.*/tool\\.html$
+            files: ^content/tools/html/.*/tool\.html$
             pass_filenames: true

--- a/content/tools/html/cron-converter/changelog.md
+++ b/content/tools/html/cron-converter/changelog.md
@@ -1,3 +1,11 @@
+## `abfb121` - February 26, 2026 11:49
+
+- Restore cron converter formatting and keep calendar fix
+
+## `22745c0` - February 26, 2026 11:48
+
+- Fix cron calendar panel centering
+
 ---
 title: Changelog - Cron Timezone Converter
 bookHidden: true

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -40,7 +40,7 @@ tools:
       toolbox:
         file: "tool.html"
         introduced_commit: "5c2c9aa8c6cde866191c8a1316111ce67acaeb17"
-        updated_commit: null
+        updated_commit: "abfb1216472b1464848b00f2b6a0e7b93c2e7096"
       tags:
         - "html"
         - "cron"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,38 @@
+# https://mise.jdx.dev/dev-tools/mise-lock.html#enabling-lockfiles
+[settings]
+# Push the MISE managed path to the front of the PATH variable
+activate_aggressive = true
+env_cache = true
+exec_auto_install = true
+github_attestations = true
+lockfile = true
+pin = true
+slsa = true
+
+[task_config]
+includes = ["mise/tasks"]
+
+[tools]
+python = "3.14.3"
+hugo-extended = "0.160.0"
+pinact = "3.9.0"
+
+
+markdownlint-cli2 = "0.22.0"
+prek = "0.3.8"
+ruff = "0.15.11"
+
+
+# Let uv manage project environments and dependencies while mise pins the CLI.
+uv = "0.11.7"
+
+# For simulating/running some of the GH/A actions locally.
+act = "0.2.87"
+kind = "0.31.0"
+
+# Render changelogs and GitHub release bodies.
+# See: https://github.com/orhun/git-cliff
+git-cliff = "2.12.0"
+
+[settings.pipx]
+uvx = true

--- a/mise/tasks/bootstrap
+++ b/mise/tasks/bootstrap
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Install the project toolchain and sync Python dependency groups"
+
+set -euo pipefail
+
+mise install
+uv sync --all-groups

--- a/mise/tasks/check/analytics
+++ b/mise/tasks/check/analytics
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Check HTML tools include the local analytics snippet"
+
+set -euo pipefail
+
+uv run ci/check_tool_analytics.py "$@"

--- a/mise/tasks/generate/_default
+++ b/mise/tasks/generate/_default
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Regenerate tracked site metadata and tool changelogs"
+#MISE depends=["generate:tools-data", "generate:changelogs"]
+
+set -euo pipefail

--- a/mise/tasks/generate/changelogs
+++ b/mise/tasks/generate/changelogs
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Refresh per-tool changelog.md files from git history"
+
+set -euo pipefail
+
+uv run ci/build_tool_changelogs.py

--- a/mise/tasks/generate/tools-data
+++ b/mise/tasks/generate/tools-data
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Rebuild data/tools.yaml and static/tools.txt"
+
+set -euo pipefail
+
+uv run ci/build_tools_data.py

--- a/mise/tasks/lint
+++ b/mise/tasks/lint
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Run the full pre-commit hook suite"
+
+set -euo pipefail
+
+uv run pre-commit run --all-files

--- a/mise/tasks/release/build-pages
+++ b/mise/tasks/release/build-pages
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="CI helper: refresh generated files and build the Pages artifact"
+#MISE depends=["release:refresh-generated"]
+
+set -euo pipefail
+
+hugo --minify

--- a/mise/tasks/release/refresh-generated
+++ b/mise/tasks/release/refresh-generated
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#MISE description="CI helper: regenerate tracked files and push if they changed"
+#MISE depends=["generate"]
+
+set -euo pipefail
+
+join_by() {
+    local separator="$1"
+    shift
+    local first=1
+    for item in "$@"; do
+        if [[ $first -eq 1 ]]; then
+            printf '%s' "$item"
+            first=0
+        else
+            printf '%s%s' "$separator" "$item"
+        fi
+    done
+}
+
+changes=()
+
+if ! git diff --quiet HEAD -- data/tools.yaml; then
+    tools_changes="$(uv run ci/detect_tools_changes.py || true)"
+    if [[ -z "$tools_changes" ]]; then
+        tools_changes="data/tools.yaml updated"
+    fi
+    changes+=("$tools_changes")
+fi
+
+if ! git diff --quiet HEAD -- static/tools.txt; then
+    changes+=("static/tools.txt updated")
+fi
+
+if ! git diff --quiet HEAD -- 'content/tools/**/changelog.md'; then
+    changelog_count="$(git diff --name-only HEAD -- 'content/tools/**/changelog.md' | wc -l | tr -d ' ')"
+    changes+=("${changelog_count} changelog(s) updated")
+fi
+
+if [[ ${#changes[@]} -eq 0 ]]; then
+    echo "No generated file changes detected."
+    exit 0
+fi
+
+summary="$(join_by '; ' "${changes[@]}")"
+echo "Generated file changes: ${summary}"
+
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "DRY_RUN=1 set, skipping commit and push."
+    exit 0
+fi
+
+git add data/tools.yaml static/tools.txt 'content/tools/**/changelog.md'
+git -c user.name=Automated -c user.email=actions@users.noreply.github.com commit -m "Update generated site data: ${summary}" || exit 0
+git push

--- a/mise/tasks/site/build
+++ b/mise/tasks/site/build
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Build the Hugo site into public/"
+
+set -euo pipefail
+
+hugo --minify

--- a/mise/tasks/site/serve
+++ b/mise/tasks/site/serve
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Run the local Hugo development server"
+#MISE raw=true
+
+set -euo pipefail
+
+hugo server -D

--- a/readme.md
+++ b/readme.md
@@ -8,11 +8,21 @@ This is powered by Hugo and the "rendered" site is hosted via [GitHub Pages](htt
 
 // TODO: llm diagram of the deploy process for GitHub Pages and add to this `readme.md`
 
+## Developer workflow
+
+This repo uses [`mise`](https://mise.jdx.dev/) for toolchain and task orchestration, with `uv` handling Python environments and dependencies.
+
+Common commands:
+
+- `mise install`: install the pinned CLI toolchain
+- `mise run bootstrap`: install the toolchain and sync all Python dependency groups
+- `mise run lint`: run the full pre-commit suite
+- `mise run generate`: refresh `data/tools.yaml`, `static/tools.txt`, and per-tool changelogs
+- `mise run site:build`: render the static site into `public/`
+- `mise run site:serve`: run the local Hugo development server
+
 ## TODOs
 
 - more/betteR  `CI` to get:
-  - `hugo` w/ the right binary version made available to LLM/agents
   - `playwright` setup for HTML tool testing
   - screenshot or similar tool to automated screenshotting of docs/tools for use in `data/tools.yaml` (for landing page cards)
-
-(really, `uv`)


### PR DESCRIPTION
## Summary
- move repo orchestration into `mise` by adding repo-level file tasks for bootstrap, lint, generation, site build/serve, and the current Pages release helpers
- update `mise.toml` to discover `mise/tasks` and pin the core runtime/toolchain used by local development and CI
- switch the pre-commit and Pages GitHub Actions workflows to `jdx/mise-action` plus `mise run ...`, while keeping the current `gh-pages` release model intact for this phase
- update the local analytics pre-commit hook to call the new `mise` task and document the developer workflow in the README
- commit the regenerated `data/tools.yaml` and cron-converter changelog output produced by the new generation flow

## Why
The repo already had version pinning started in `mise.toml`, but orchestration still lived mostly in workflow YAML and ad hoc command sequences. This change makes local and CI execution converge on the same task entrypoints without yet changing the branch-based Pages release process.

## Impact
- contributors can use stable `mise run ...` commands locally instead of reproducing workflow steps by hand
- CI now installs the same pinned toolchain and runs the same tasks as local development
- the current release flow is preserved, but the multi-step branch update/build logic now lives in one `mise` task tree instead of inline workflow shell

## Validation
- `mise tasks`
- `mise run generate`
- `mise run site:build`
- `DRY_RUN=1 mise run release:build-pages`
- `mise run check:analytics -- content/tools/html/cron-converter/tool.html`
- `mise run lint`
