### PR TITLE
[codex] Fix pre-commit workflow concurrency

### DIFF
--- a/.github/workflows/ci_pre-commit.yaml
+++ b/.github/workflows/ci_pre-commit.yaml
@@ -16,6 +16,10 @@ on:
         branches-ignore:
             - main
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+    cancel-in-progress: true
+
 jobs:
     pre-commit:
         name: run pre-commit hooks


### PR DESCRIPTION
## Summary

- Adds workflow-level concurrency to the Pre-Commit workflow.
- Keys concurrency by workflow, source repository, and source branch so push and pull_request events for the same PR branch cancel duplicates.

## Validation

- `prek run check-yaml zizmor --all-files`
- commit hook suite for `.github/workflows/ci_pre-commit.yaml`
