### PR TITLE
[codex] Add Obsidian Icon Folder migrator

### DIFF
--- a/content/tools/python/obsidian-icon-folder-migrator/_index.md
+++ b/content/tools/python/obsidian-icon-folder-migrator/_index.md
@@ -1,0 +1,70 @@
+---
+date: 2026-06-21
+draft: false
+title: "Obsidian Icon Folder Migrator"
+description: "Move Obsidian Icon Folder plugin icon assignments from data.json into note YAML frontmatter."
+bookToc: false
+
+resources:
+  - name: tool-file
+    src: tool.py
+  - name: tool-icon
+    src: images/tool-icon.svg
+
+tags:
+  - obsidian
+  - markdown
+  - yaml
+  - frontmatter
+  - migration
+  - python
+---
+
+# Obsidian Icon Folder Migrator
+
+{{< tool-image >}}
+
+Migrate icon assignments from the old Obsidian Icon Folder plugin data file into each note's YAML frontmatter.
+The tool reads `.obsidian/plugins/obsidian-icon-folder/data.json`, resolves each vault-relative entry to an existing Markdown note, and adds `icon: ...` to that note.
+
+It is designed for cautious cleanup work: dry-run is the default, files are never created or moved, existing `icon` values are preserved unless you explicitly pass `--update-existing`, and successfully migrated JSON entries can optionally be removed with `--remove-from-json`.
+
+## Example Usage
+
+```shell
+{{< py-usage >}}
+```
+
+```shell
+# Preview what would change in the current directory vault.
+uv run ./tool.py --vault-root ~/Notes
+
+# Write note frontmatter updates after reviewing the dry run.
+uv run ./tool.py --vault-root ~/Notes --no-dry-run
+
+# Replace differing existing frontmatter icon values.
+uv run ./tool.py --vault-root ~/Notes --update-existing --no-dry-run
+
+# Remove data.json entries after they are migrated or already match.
+uv run ./tool.py --vault-root ~/Notes --remove-from-json --no-dry-run
+
+# Also remove data.json keys that no longer resolve to notes.
+uv run ./tool.py --vault-root ~/Notes --on-missing remove --remove-from-json --no-dry-run
+```
+
+## Behavior
+
+- Reads string icon values and object values with `iconName`.
+- Resolves note paths directly, folder paths through `index.md`, and extensionless paths through `<path>.md`.
+- Adds `icon` as the last frontmatter key when it is missing.
+- Leaves an existing matching `icon` untouched.
+- Skips a differing existing `icon` unless `--update-existing` is passed.
+- Skips unsafe absolute paths and paths containing `..`.
+
+## Dependencies
+
+{{< tool-dependencies >}}
+
+## Changelog
+
+{{< tool-changelog >}}

--- a/content/tools/python/obsidian-icon-folder-migrator/changelog.md
+++ b/content/tools/python/obsidian-icon-folder-migrator/changelog.md
@@ -1,0 +1,9 @@
+---
+title: Changelog - Obsidian Icon Folder Migrator
+bookHidden: true
+---
+## `dbdf1e2` - June 21, 2026 14:20
+
+- feat: add obsidian icon folder migrator
+
+[view history on github](https://github.com/kquinsland/tools/commits/main/content/tools/python/obsidian-icon-folder-migrator/tool.py)

--- a/content/tools/python/obsidian-icon-folder-migrator/images/tool-icon.svg
+++ b/content/tools/python/obsidian-icon-folder-migrator/images/tool-icon.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Obsidian Icon Folder Migrator icon</title>
+  <desc id="desc">A markdown note receiving an icon value from a plugin data file.</desc>
+  <defs>
+    <linearGradient id="bg" x1="72" y1="48" x2="440" y2="464" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#dbe4ee"/>
+    </linearGradient>
+    <linearGradient id="note" x1="174" y1="80" x2="366" y2="430" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffffff"/>
+      <stop offset="1" stop-color="#eef3f8"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feDropShadow dx="0" dy="16" stdDeviation="18" flood-color="#1f2937" flood-opacity=".18"/>
+    </filter>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#bg)"/>
+  <g filter="url(#shadow)">
+    <path d="M166 76h142l70 72v284H166z" fill="url(#note)"/>
+    <path d="M308 76v72h70z" fill="#d5dde8"/>
+    <path d="M166 76h142l70 72v284H166z" fill="none" stroke="#334155" stroke-width="12" stroke-linejoin="round"/>
+    <path d="M308 76v72h70" fill="none" stroke="#334155" stroke-width="12" stroke-linejoin="round"/>
+  </g>
+  <rect x="202" y="178" width="132" height="44" rx="12" fill="#6d5dfc" opacity=".92"/>
+  <rect x="202" y="246" width="104" height="16" rx="8" fill="#94a3b8"/>
+  <rect x="202" y="282" width="136" height="16" rx="8" fill="#94a3b8"/>
+  <rect x="202" y="318" width="82" height="16" rx="8" fill="#94a3b8"/>
+  <path d="M82 180h112a24 24 0 0 1 24 24v64a24 24 0 0 1-24 24H82a24 24 0 0 1-24-24v-64a24 24 0 0 1 24-24z" fill="#1f2937"/>
+  <path d="M94 211h70M94 237h94M94 263h56" stroke="#cbd5e1" stroke-width="12" stroke-linecap="round"/>
+  <path d="M221 236h98" stroke="#f59e0b" stroke-width="18" stroke-linecap="round"/>
+  <path d="M304 205l52 31-52 31" fill="none" stroke="#f59e0b" stroke-width="18" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="398" cy="342" r="46" fill="#f59e0b"/>
+  <path d="M398 316l8 17 19 3-14 14 3 19-16-9-17 9 3-19-14-14 19-3z" fill="#fff7ed"/>
+</svg>

--- a/content/tools/python/obsidian-icon-folder-migrator/tool.py
+++ b/content/tools/python/obsidian-icon-folder-migrator/tool.py
@@ -1,0 +1,463 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "click>=8.1",
+#   "ruamel.yaml>=0.18",
+#   "structlog>=24",
+# ]
+# ///
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+from typing import Any, Literal
+
+import click
+import structlog
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+
+
+ICON_FRONTMATTER_KEY = "icon"
+DEFAULT_DATA_JSON = ".obsidian/plugins/obsidian-icon-folder/data.json"
+MissingBehavior = Literal["silent", "warn", "remove"]
+
+
+yaml = YAML(typ="rt")
+yaml.preserve_quotes = True
+yaml.allow_unicode = True
+yaml.default_flow_style = False
+
+
+@dataclass(frozen=True)
+class IconEntry:
+    key: str
+    icon: str
+    note_path: Path
+
+
+@dataclass(frozen=True)
+class IconLoadResult:
+    entries: list[IconEntry]
+    missing_keys: set[str]
+
+
+@dataclass(frozen=True)
+class FrontmatterParts:
+    frontmatter: str | None
+    body: str
+
+
+@dataclass(frozen=True)
+class NoteUpdate:
+    changed: bool
+    removable: bool
+    reason: str
+    text: str
+
+
+def configure_logging() -> None:
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.dev.ConsoleRenderer(),
+        ],
+    )
+
+
+def extract_icon(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict) and isinstance(value.get("iconName"), str):
+        return value["iconName"]
+    return None
+
+
+def safe_relative_path(raw_path: str) -> Path | None:
+    relative_path = Path(raw_path)
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        return None
+    return relative_path
+
+
+def resolve_note_path(vault_root: Path, raw_path: str) -> Path | None:
+    relative_path = safe_relative_path(raw_path)
+    if relative_path is None:
+        return None
+
+    candidate = vault_root / relative_path
+
+    if candidate.is_file() and candidate.suffix.lower() == ".md":
+        return candidate
+
+    if relative_path.suffix.lower() == ".md":
+        return candidate if candidate.is_file() else None
+
+    if candidate.is_dir():
+        index_note = candidate / "index.md"
+        if index_note.is_file():
+            return index_note
+
+    markdown_candidate = vault_root / f"{raw_path}.md"
+    if markdown_candidate.is_file():
+        return markdown_candidate
+
+    return None
+
+
+def split_frontmatter(text: str) -> FrontmatterParts:
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return FrontmatterParts(frontmatter=None, body=text)
+
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() in {"---", "..."}:
+            return FrontmatterParts(
+                frontmatter="".join(lines[1:index]),
+                body="".join(lines[index + 1 :]),
+            )
+
+    return FrontmatterParts(frontmatter=None, body=text)
+
+
+def load_frontmatter(frontmatter_text: str | None) -> CommentedMap:
+    if frontmatter_text is None or not frontmatter_text.strip():
+        return CommentedMap()
+
+    loaded = yaml.load(frontmatter_text)
+    if loaded is None:
+        return CommentedMap()
+    if not isinstance(loaded, CommentedMap):
+        msg = "Frontmatter is not a YAML mapping"
+        raise ValueError(msg)
+    return loaded
+
+
+def dump_frontmatter(frontmatter: CommentedMap) -> str:
+    stream = StringIO()
+    yaml.dump(frontmatter, stream)
+    return stream.getvalue()
+
+
+def dump_icon_line(icon: str) -> str:
+    icon_frontmatter = CommentedMap()
+    icon_frontmatter[ICON_FRONTMATTER_KEY] = icon
+    return dump_frontmatter(icon_frontmatter)
+
+
+def append_icon(frontmatter_text: str | None, icon: str) -> str:
+    icon_line = dump_icon_line(icon)
+    if frontmatter_text is None or not frontmatter_text:
+        return icon_line
+    if frontmatter_text.endswith(("\n", "\r")):
+        return f"{frontmatter_text}{icon_line}"
+    return f"{frontmatter_text}\n{icon_line}"
+
+
+def replace_icon(frontmatter_text: str, frontmatter: CommentedMap, icon: str) -> str:
+    icon_location = frontmatter.lc.key(ICON_FRONTMATTER_KEY)
+    icon_line_index = icon_location[0]
+    lines = frontmatter_text.splitlines(keepends=True)
+    existing_line = lines[icon_line_index]
+    base_indent = len(existing_line) - len(existing_line.lstrip(" "))
+
+    end_line_index = icon_line_index + 1
+    while end_line_index < len(lines):
+        line = lines[end_line_index]
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if stripped and not stripped.startswith("#") and indent <= base_indent:
+            break
+        end_line_index += 1
+
+    return "".join(
+        [
+            *lines[:icon_line_index],
+            dump_icon_line(icon),
+            *lines[end_line_index:],
+        ],
+    )
+
+
+def update_note_text(
+    original_text: str,
+    icon: str,
+    *,
+    update_existing: bool,
+) -> NoteUpdate:
+    parts = split_frontmatter(original_text)
+    frontmatter = load_frontmatter(parts.frontmatter)
+
+    if ICON_FRONTMATTER_KEY in frontmatter:
+        current_icon = frontmatter[ICON_FRONTMATTER_KEY]
+        if current_icon == icon:
+            return NoteUpdate(
+                changed=False,
+                removable=True,
+                reason="icon already matches",
+                text=original_text,
+            )
+        if not update_existing:
+            return NoteUpdate(
+                changed=False,
+                removable=False,
+                reason="existing icon differs; use --update-existing to replace it",
+                text=original_text,
+            )
+
+        rendered = render_note(
+            parts, replace_icon(parts.frontmatter or "", frontmatter, icon)
+        )
+        return NoteUpdate(
+            changed=rendered != original_text,
+            removable=True,
+            reason="updated existing icon",
+            text=rendered,
+        )
+
+    rendered = render_note(parts, append_icon(parts.frontmatter, icon))
+    return NoteUpdate(
+        changed=rendered != original_text,
+        removable=True,
+        reason="added icon",
+        text=rendered,
+    )
+
+
+def render_note(parts: FrontmatterParts, frontmatter_text: str) -> str:
+    body = parts.body
+    if parts.frontmatter is None and body:
+        return f"---\n{frontmatter_text}---\n\n{body}"
+    return f"---\n{frontmatter_text}---\n{body}"
+
+
+def load_icon_entries(
+    data: dict[str, Any],
+    *,
+    vault_root: Path,
+    missing_behavior: MissingBehavior,
+    log: structlog.stdlib.BoundLogger,
+) -> IconLoadResult:
+    entries: list[IconEntry] = []
+    missing_keys: set[str] = set()
+
+    for key, value in data.items():
+        if key == "settings":
+            continue
+
+        icon = extract_icon(value)
+        if icon is None:
+            log.warning("Skipping entry without a usable icon", key=key)
+            continue
+
+        note_path = resolve_note_path(vault_root, key)
+        if note_path is None:
+            missing_keys.add(key)
+            if missing_behavior == "warn":
+                log.warning("No existing note file found for data.json key", key=key)
+            continue
+
+        entries.append(IconEntry(key=key, icon=icon, note_path=note_path))
+
+    return IconLoadResult(entries=entries, missing_keys=missing_keys)
+
+
+def write_data_json(data_json_path: Path, data: dict[str, Any]) -> None:
+    data_json_path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+@click.command()
+@click.option(
+    "--vault-root",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("."),
+    show_default=True,
+    help="Path to the Obsidian vault root.",
+)
+@click.option(
+    "--data-json",
+    "data_json_path",
+    type=click.Path(path_type=Path, file_okay=True, dir_okay=False),
+    default=Path(DEFAULT_DATA_JSON),
+    show_default=True,
+    help="Path to obsidian-icon-folder data.json.",
+)
+@click.option(
+    "--on-missing",
+    type=click.Choice(["silent", "warn", "remove"], case_sensitive=False),
+    default="warn",
+    show_default=True,
+    help="How to handle a data.json key that does not resolve to an existing note.",
+)
+@click.option(
+    "--update-existing",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Replace an existing frontmatter icon value when it differs.",
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=True,
+    show_default=True,
+    help="Show planned changes without writing files.",
+)
+@click.option(
+    "--remove-from-json",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Remove migrated entries from data.json after the note is updated or already matches.",
+)
+def main(
+    vault_root: Path,
+    data_json_path: Path,
+    on_missing: MissingBehavior,
+    update_existing: bool,
+    dry_run: bool,
+    remove_from_json: bool,
+) -> None:
+    """Move obsidian-icon-folder icon values into note frontmatter."""
+    configure_logging()
+    log = structlog.get_logger()
+
+    vault_root = vault_root.expanduser().resolve()
+    data_json_path = data_json_path.expanduser()
+    if not data_json_path.is_absolute():
+        data_json_path = vault_root / data_json_path
+    data_json_path = data_json_path.resolve()
+
+    data = json.loads(data_json_path.read_text(encoding="utf-8"))
+    load_result = load_icon_entries(
+        data,
+        vault_root=vault_root,
+        missing_behavior=on_missing,
+        log=log,
+    )
+    entries = load_result.entries
+
+    entries_by_note: dict[Path, list[IconEntry]] = defaultdict(list)
+    for entry in entries:
+        entries_by_note[entry.note_path].append(entry)
+
+    changed_notes = 0
+    removable_keys: set[str] = set()
+    skipped_notes = 0
+
+    for note_path, note_entries in entries_by_note.items():
+        icons = {entry.icon for entry in note_entries}
+        relative_note = note_path.relative_to(vault_root)
+
+        if len(icons) > 1:
+            skipped_notes += 1
+            log.warning(
+                "Skipping note because multiple data.json keys resolve to it with different icons",
+                note=str(relative_note),
+                keys=[entry.key for entry in note_entries],
+                icons=sorted(icons),
+            )
+            continue
+
+        icon = note_entries[0].icon
+        original_text = note_path.read_text(encoding="utf-8")
+
+        try:
+            update = update_note_text(
+                original_text,
+                icon,
+                update_existing=update_existing,
+            )
+        except ValueError as error:
+            skipped_notes += 1
+            log.warning(
+                "Skipping note",
+                note=str(relative_note),
+                reason=str(error),
+            )
+            continue
+
+        if update.changed:
+            changed_notes += 1
+            if dry_run:
+                log.info(
+                    "Would update note frontmatter",
+                    note=str(relative_note),
+                    icon=icon,
+                    reason=update.reason,
+                )
+            else:
+                note_path.write_text(update.text, encoding="utf-8")
+                log.info(
+                    "Updated note frontmatter",
+                    note=str(relative_note),
+                    icon=icon,
+                    reason=update.reason,
+                )
+        else:
+            if update.removable:
+                log.info(
+                    "No note change needed",
+                    note=str(relative_note),
+                    icon=icon,
+                    reason=update.reason,
+                )
+            else:
+                skipped_notes += 1
+                log.warning(
+                    "Skipping note",
+                    note=str(relative_note),
+                    icon=icon,
+                    reason=update.reason,
+                )
+
+        if update.removable:
+            removable_keys.update(entry.key for entry in note_entries)
+
+    missing_keys_to_remove = (
+        load_result.missing_keys if on_missing == "remove" else set()
+    )
+    data_json_keys_to_remove: set[str] = set()
+    if remove_from_json:
+        data_json_keys_to_remove.update(removable_keys)
+    data_json_keys_to_remove.update(missing_keys_to_remove)
+
+    if data_json_keys_to_remove:
+        if dry_run:
+            log.info(
+                "Would remove entries from data.json",
+                count=len(data_json_keys_to_remove),
+                migrated_count=len(removable_keys) if remove_from_json else 0,
+                missing_count=len(missing_keys_to_remove),
+                keys=sorted(data_json_keys_to_remove),
+            )
+        else:
+            for key in data_json_keys_to_remove:
+                data.pop(key, None)
+            write_data_json(data_json_path, data)
+            log.info(
+                "Removed entries from data.json",
+                count=len(data_json_keys_to_remove),
+                migrated_count=len(removable_keys) if remove_from_json else 0,
+                missing_count=len(missing_keys_to_remove),
+                path=str(data_json_path.relative_to(vault_root)),
+            )
+
+    log.info(
+        "Finished",
+        changed_notes=changed_notes,
+        skipped_notes=skipped_notes,
+        removable_migrated_data_json_entries=len(removable_keys),
+        missing_data_json_entries=len(load_result.missing_keys),
+        dry_run=dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -321,7 +321,7 @@ tools:
       description: "Move Obsidian Icon Folder plugin icon assignments from data.json into note YAML frontmatter."
       toolbox:
         file: "tool.py"
-        introduced_commit: null
+        introduced_commit: "dbdf1e2fdb2fcf31dcc5dc583e73d0b4c8b30499"
         updated_commit: null
       dependencies:
         - package: "click"

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -315,3 +315,25 @@ tools:
         file: "tool.py"
         introduced_commit: "dc47d301b4ad8c2b59a7d607af6b239499a3b646"
         updated_commit: "d24e9d9051d2035edab93d7350edb0e3586a6162"
+  - python/obsidian-icon-folder-migrator:
+      title: "Obsidian Icon Folder Migrator"
+      language: "python"
+      description: "Move Obsidian Icon Folder plugin icon assignments from data.json into note YAML frontmatter."
+      toolbox:
+        file: "tool.py"
+        introduced_commit: null
+        updated_commit: null
+      dependencies:
+        - package: "click"
+          version: ">=8.1"
+        - package: "ruamel.yaml"
+          version: ">=0.18"
+        - package: "structlog"
+          version: ">=24"
+      tags:
+        - "obsidian"
+        - "markdown"
+        - "yaml"
+        - "frontmatter"
+        - "migration"
+        - "python"

--- a/static/tools.txt
+++ b/static/tools.txt
@@ -24,3 +24,4 @@
 
 - [GHA Tree Builder](https://tools.karlquinsland.com/tools/python/gha-tree-builder/): Generate DOT dependency graphs for GitHub Actions workflows, triggers, and jobs.
 - [Hello, Python](https://tools.karlquinsland.com/tools/python/hello-python/): This is the first tool description here.
+- [Obsidian Icon Folder Migrator](https://tools.karlquinsland.com/tools/python/obsidian-icon-folder-migrator/): Move Obsidian Icon Folder plugin icon assignments from data.json into note YAML frontmatter.


### PR DESCRIPTION
## Summary

Adds a new Python tool page for migrating Obsidian Icon Folder plugin assignments from `.obsidian/plugins/obsidian-icon-folder/data.json` into note YAML frontmatter.

## Changes

- Add the standalone PEP 723 `tool.py` script with Click CLI options, dry-run default, missing-entry handling, and optional JSON cleanup.
- Add a Hugo page bundle with usage docs, dependency metadata, generated changelog, and an SVG tool icon.
- Refresh `data/tools.yaml` and `static/tools.txt` so the tool appears in listings.

## Validation

- `uv run ruff check content/tools/python/obsidian-icon-folder-migrator/tool.py`
- `uv run ruff format --check content/tools/python/obsidian-icon-folder-migrator/tool.py`
- `uv run content/tools/python/obsidian-icon-folder-migrator/tool.py --help`
- Temp-vault smoke test for note migration, folder `index.md` migration, and `--remove-from-json`
- `hugo --buildDrafts --cleanDestinationDir`

Hugo reports existing deprecation warnings and unrelated missing-image warnings for older pages; no new warnings from this tool.
