### PR TITLE
feat: add bulk URL parameter removal

### DIFF
--- a/content/tools/html/url-markdown-links/changelog.md
+++ b/content/tools/html/url-markdown-links/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog - URL to Markdown Links
 bookHidden: true
 ---
+## `2de1c45` - June 21, 2026 16:35
+
+- feat: add bulk URL parameter removal
+
 ## `ce1dbba` - January 12, 2026 17:42
 
 - feat: Dark Mode:

--- a/content/tools/html/url-markdown-links/tool.html
+++ b/content/tools/html/url-markdown-links/tool.html
@@ -336,6 +336,9 @@
           </div>
           <div class="option-group" style="justify-items: start;">
             <label><input type="checkbox" id="option-dedupe" /> Dedupe URLs</label>
+            <button id="strip-params-button" class="secondary" type="button" disabled>
+              Remove URL params
+            </button>
           </div>
         </div>
         <ul id="url-list" class="url-list"></ul>
@@ -397,6 +400,7 @@
       const clearButton = document.getElementById("clear-button");
       const clearInputTop = document.getElementById("clear-input-top");
       const clearLogButton = document.getElementById("clear-log");
+      const stripParamsButton = document.getElementById("strip-params-button");
       const logList = document.getElementById("log-list");
       const logEmpty = document.getElementById("log-empty");
       const linkTextOptions = document.querySelectorAll("input[name='link-text']");
@@ -514,9 +518,45 @@
         return cleaned;
       }
 
+      function hasUrlParams(value) {
+        try {
+          return Boolean(new URL(value).search);
+        } catch (error) {
+          return false;
+        }
+      }
+
+      function stripUrlParams(value) {
+        try {
+          const parsed = new URL(value);
+          if (!parsed.search) return value;
+          parsed.search = "";
+          return parsed.toString();
+        } catch (error) {
+          return value;
+        }
+      }
+
+      function stripParamsFromInput(value) {
+        const regex = /https?:\/\/[^\s<>'"`]+/gi;
+        let changed = 0;
+        const text = value.replace(regex, (match) => {
+          const suffixMatch = match.match(/[)\],.!?:;>]+$/);
+          const suffix = suffixMatch ? suffixMatch[0] : "";
+          const url = suffix ? match.slice(0, -suffix.length) : match;
+          const stripped = stripUrlParams(url);
+          if (stripped !== url) {
+            changed += 1;
+          }
+          return `${stripped}${suffix}`;
+        });
+        return { text, changed };
+      }
+
       function renderUrlList() {
         urlListEl.innerHTML = "";
         urlCountEl.textContent = urls.length.toString();
+        stripParamsButton.disabled = !urls.some(hasUrlParams);
         if (!urls.length) {
           urlListEl.innerHTML = "<li>Paste text above to extract URLs.</li>";
           return;
@@ -790,8 +830,26 @@
         refresh();
       }
 
+      function removeAllUrlParams() {
+        const result = stripParamsFromInput(inputEl.value);
+        if (!result.changed) {
+          addLog("No URL parameters found to remove.");
+          return;
+        }
+
+        inputEl.value = result.text;
+        saveInput(inputEl.value);
+        titleCache.clear();
+        pendingTitles.clear();
+        addLog(
+          `Removed URL parameters from ${result.changed} URL${result.changed === 1 ? "" : "s"}.`,
+        );
+        refresh();
+      }
+
       clearButton.addEventListener("click", clearInput);
       clearInputTop.addEventListener("click", clearInput);
+      stripParamsButton.addEventListener("click", removeAllUrlParams);
 
       clearLogButton.addEventListener("click", clearLog);
 

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -254,7 +254,7 @@ tools:
       toolbox:
         file: "tool.html"
         introduced_commit: "eee81257ad54ff8cf9d9c21400203d238cbfbb36"
-        updated_commit: "138614d7170f9bc2b37262fd77a158bda904a37e"
+        updated_commit: "2de1c45c20b1dd91602b51c7d22a9ba48d006c29"
       tags:
         - "html"
         - "url"


### PR DESCRIPTION
## Summary
- add a bulk "Remove URL params" action to the URL to Markdown Links tool
- rewrite matching URLs in the source textarea so local storage, hash state, extracted URL list, and Markdown output stay in sync
- refresh generated changelog and tool metadata for the updated tool

Closes #131

## Verification
- `mise run lint`
- `mise run check:generated`
- `mise run site:build`
