### PR TITLE
[codex] fix changelog heading warning

### DIFF
--- a/ci/build_tool_changelogs.py
+++ b/ci/build_tool_changelogs.py
@@ -285,6 +285,16 @@ def _split_front_matter(text: str) -> tuple[str, str]:
     return "", text
 
 
+def _has_unrecognized_changelog_body(*, text: str, history_link: str) -> bool:
+    _, body = _split_front_matter(text)
+    meaningful_lines = [
+        line.strip()
+        for line in body.splitlines()
+        if line.strip() and line.strip() != history_link
+    ]
+    return bool(meaningful_lines)
+
+
 def _update_changelog(
     *,
     repo_root: Path,
@@ -309,7 +319,10 @@ def _update_changelog(
         )
 
     top_hash = _extract_top_hash(existing_text)
-    if top_hash is None and existing_text.strip():
+    if top_hash is None and _has_unrecognized_changelog_body(
+        text=existing_text,
+        history_link=_render_history_link(repo_root=repo_root, tool_dir=tool_dir),
+    ):
         LOG.warning(
             "changelog missing heading hash; skipping",
             tool=str(tool_dir),
@@ -458,6 +471,26 @@ def test_render_history_link_uses_tool_file() -> None:
         assert link.endswith("content/tools/html/demo/custom.html)")
 
 
+def test_has_unrecognized_changelog_body_ignores_front_matter_and_history_link() -> (
+    None
+):
+    history_link = "[view history on github](https://example.com/history)"
+    text = "\n".join(
+        [
+            "---",
+            "title: Changelog - Demo",
+            "bookHidden: true",
+            "---",
+            "",
+            history_link,
+            "",
+        ]
+    )
+    assert (
+        _has_unrecognized_changelog_body(text=text, history_link=history_link) is False
+    )
+
+
 def _git(args: list[str], *, cwd: Path) -> None:
     subprocess.run(["git", *args], cwd=cwd, check=True, text=True)
 
@@ -567,6 +600,42 @@ def test_update_changelog_preserves_front_matter() -> None:
         )
         assert f"---\n## `{second_hash}`" in updated
         assert f"## `{first_hash}`" in updated
+
+
+def test_update_changelog_backfills_front_matter_only_file() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        _git(["init"], cwd=repo)
+        _git(["config", "user.email", "test@example.com"], cwd=repo)
+        _git(["config", "user.name", "Test User"], cwd=repo)
+
+        tool_dir = repo / "content" / "tools" / "html" / "demo"
+        tool_dir.mkdir(parents=True)
+        (tool_dir / "_index.md").write_text("---\ntitle: Demo\n---\n", encoding="utf-8")
+        (tool_dir / "tool.html").write_text("<html></html>", encoding="utf-8")
+        _git(["add", "."], cwd=repo)
+        _git(["commit", "-m", "Init tool"], cwd=repo)
+        first_hash = _run_git(["rev-parse", "--short", "HEAD"], cwd=repo)
+
+        changelog = tool_dir / "changelog.md"
+        changelog.write_text(
+            "---\ntitle: Changelog - Demo\nbookHidden: true\n---\n",
+            encoding="utf-8",
+        )
+
+        changed = _update_changelog(
+            repo_root=repo,
+            tool_dir=tool_dir,
+            changelog_path=changelog,
+            init=False,
+        )
+        assert changed is True
+        updated = changelog.read_text(encoding="utf-8")
+        assert updated.startswith(
+            "---\ntitle: Changelog - Demo\nbookHidden: true\n---\n"
+        )
+        assert f"## `{first_hash}`" in updated
+        assert HISTORY_LINK_TEXT in updated
 
 
 def test_init_creates_changelog() -> None:

--- a/content/tools/html/container-registry-browser/changelog.md
+++ b/content/tools/html/container-registry-browser/changelog.md
@@ -2,3 +2,8 @@
 title: Changelog - Container Registry Browser
 bookHidden: true
 ---
+## `0ecd055` - April 25, 2026 13:13
+
+- Add container registry browser tool
+
+[view history on github](https://github.com/kquinsland/tools/commits/main/content/tools/html/container-registry-browser/tool.html)

--- a/content/tools/html/exif-inspector/changelog.md
+++ b/content/tools/html/exif-inspector/changelog.md
@@ -2,3 +2,8 @@
 title: Changelog - EXIF Inspector
 bookHidden: true
 ---
+## `352f381` - April 25, 2026 15:30
+
+- feat: add EXIF inspector tool
+
+[view history on github](https://github.com/kquinsland/tools/commits/main/content/tools/html/exif-inspector/tool.html)

--- a/content/tools/html/qr-code-generator/changelog.md
+++ b/content/tools/html/qr-code-generator/changelog.md
@@ -2,3 +2,12 @@
 title: Changelog - QR Code Generator
 bookHidden: true
 ---
+## `2f1d3fc` - May 8, 2026 18:59
+
+- feat: update QR calendar shortcuts
+
+## `93024de` - April 25, 2026 16:40
+
+- feat: add QR code generator tool
+
+[view history on github](https://github.com/kquinsland/tools/commits/main/content/tools/html/qr-code-generator/tool.html)

--- a/content/tools/html/syncthing-conflict-triage/changelog.md
+++ b/content/tools/html/syncthing-conflict-triage/changelog.md
@@ -2,3 +2,8 @@
 title: Changelog - Sync Conflict Triage
 bookHidden: true
 ---
+## `4bfd793` - March 31, 2026 19:46
+
+- Add Sync Conflict Triage tool
+
+[view history on github](https://github.com/kquinsland/tools/commits/main/content/tools/html/syncthing-conflict-triage/tool.html)


### PR DESCRIPTION
## Summary

- Treat front-matter-only changelogs as empty generated history instead of malformed changelog content.
- Keep the malformed-content guard for changelogs that have non-generated body text but no commit heading hash.
- Backfill the four changelogs that were previously skipped with generated commit entries and history links.

## Root Cause

ci/build_tool_changelogs.py appended the generated history link before checking for a top commit heading. Front-matter-only changelog files then had non-empty content but no `## `hash`` heading, so the script logged `changelog missing heading hash; skipping` and never backfilled them.

## Validation

- `mise run generate:changelogs`
- `uv run pytest ci/build_tool_changelogs.py`
- `uv run ruff check ci/build_tool_changelogs.py`
- `uv run ruff format --check ci/build_tool_changelogs.py`
- `mise run lint`
- `mise run site:build`
- `mise run check:generated`
