### PR TITLE
feat: style tool links as prominent buttons

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -1,0 +1,59 @@
+.markdown a.tool-link[href] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  min-height: 2.75rem;
+  margin: 0.5rem 0 1rem;
+  padding: 0.625rem 1rem;
+  border: 2px solid var(--color-link);
+  border-radius: var(--border-radius);
+  background: var(--color-link);
+  box-shadow: 0 0.2rem 0.45rem rgba(0, 0, 0, 0.18);
+  color: var(--body-background);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-decoration: none;
+  transition:
+    box-shadow 120ms ease,
+    transform 120ms ease;
+
+  &:visited,
+  &:hover {
+    color: var(--body-background);
+    text-decoration: none;
+  }
+
+  &:hover {
+    box-shadow: 0 0.3rem 0.65rem rgba(0, 0, 0, 0.25);
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    box-shadow: 0 0.1rem 0.25rem rgba(0, 0, 0, 0.2);
+    transform: translateY(1px);
+  }
+
+  &:focus-visible {
+    outline: 3px solid var(--color-link);
+    outline-offset: 3px;
+  }
+
+  .tool-link-icon {
+    font-size: 1.2em;
+    line-height: 1;
+    transition: transform 120ms ease;
+  }
+
+  &:hover .tool-link-icon {
+    transform: translateX(0.15rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .markdown a.tool-link[href],
+  .markdown a.tool-link[href] .tool-link-icon {
+    transition: none;
+  }
+}

--- a/layouts/shortcodes/tool-link.html
+++ b/layouts/shortcodes/tool-link.html
@@ -5,7 +5,7 @@
 
      Usage examples in markdown:
        [link text]({{< tool-link >}})               -> emits just the URL
-       {{< tool-link link_text="link text" >}}      -> emits <a href="...">link text</a>
+       {{< tool-link link_text="link text" >}}      -> emits a prominent link button
        {{< tool-link "link text" >}}                -> positional text
   */ -}}
 
@@ -49,7 +49,10 @@
 {{- end -}}
 
 {{- if $text -}}
-<a class="tool-link" href="{{ $href }}">{{ $text }}</a>
+<a class="book-btn tool-link" href="{{ $href }}">
+  <span>{{ $text }}</span>
+  <span class="tool-link-icon" aria-hidden="true">&rarr;</span>
+</a>
 {{- else -}}
 {{- $href -}}
 {{- end -}}


### PR DESCRIPTION
## What changed

- render text-bearing `tool-link` shortcodes as prominent theme-compatible buttons
- add a directional arrow icon while keeping it hidden from assistive technology
- add hover, active, keyboard-focus, and reduced-motion styles

## Why

Tool launch links looked like ordinary inline links, making the primary action easy to miss. The shortcode now gives those links a consistent call-to-action treatment without changing URL-only shortcode usage.

## Impact

Visitors can identify and activate tool launch links more easily across tool pages, with keyboard focus and reduced-motion preferences preserved.

## Validation

- `mise run lint`
- `mise run check:generated`
- `mise run site:build` (285 pages built)
